### PR TITLE
Address text/rdf+n3 errors.

### DIFF
--- a/inquisitor/question.py
+++ b/inquisitor/question.py
@@ -188,7 +188,9 @@ class RDFInquisitor:
         Examples:
             >>> RDFInquisitor("http://rightsstatements.org/vocab/InC/1.0/").get_labels()
             ... #doctest: +NORMALIZE_WHITESPACE
-            [(rdflib.term.Literal('Urheberrechtsschutz', lang='de'),
+            [(rdflib.term.Literal('Protegit per Drets d’Autor', lang='ca'),
+            rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel')),
+            (rdflib.term.Literal('Urheberrechtsschutz', lang='de'),
             rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel')),
             (rdflib.term.Literal('In Copyright', lang='en'),
             rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel')),
@@ -201,6 +203,8 @@ class RDFInquisitor:
             (rdflib.term.Literal("Protégé par le droit d'auteur", lang='fr'),
             rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel')),
             (rdflib.term.Literal('प्रतिलिप्यधिकार (कॉपीराइट) में', lang='hi'),
+            rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel')),
+            (rdflib.term.Literal('Zaštićeno autorskim pravom', lang='hr'),
             rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel')),
             (rdflib.term.Literal('In Copyright', lang='it'),
             rdflib.term.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel')),

--- a/inquisitor/question.py
+++ b/inquisitor/question.py
@@ -47,7 +47,6 @@ class RDFInquisitor:
         elif 'text/rdf+n3' in self.content_type:
             return Graph().parse(data=self.rdf, format="text/n3")
         else:
-            print(self.content_type)
             return Graph().parse(data=self.rdf, format=self.content_type)
 
     @staticmethod

--- a/inquisitor/question.py
+++ b/inquisitor/question.py
@@ -44,7 +44,10 @@ class RDFInquisitor:
             return Graph().parse(data=self.rdf, format="json-ld")
         elif self._valid is False:
             return Graph().parse(data=self.rdf, format="xml")
+        elif 'text/rdf+n3' in self.content_type:
+            return Graph().parse(data=self.rdf, format="text/n3")
         else:
+            print(self.content_type)
             return Graph().parse(data=self.rdf, format=self.content_type)
 
     @staticmethod


### PR DESCRIPTION
# What Does This Do

1. Addresses an issue where rdflib can't parse content with a content type of `text/rdf+n3`
2. Updates doctest for get_labels() for new languages for rightsstatements.org.